### PR TITLE
support unipipe-terraform-runner

### DIFF
--- a/examples/standard-deployment-with-terraform-runner/README.md
+++ b/examples/standard-deployment-with-terraform-runner/README.md
@@ -1,0 +1,40 @@
+# Standard deployment with GitHub integration
+
+This example spins up an UniPipe service broker with a GitHub repository as instance repository.
+
+```mermaid
+flowchart LR;
+
+subgraph repo[GitHub Repository]
+    deployKey[Deploy Key with write access]
+    cloneUrl[repository clone URL]
+end
+
+subgraph service-broker[unipipe-service-broker container in Azure]
+    instanceRepoURL[instance repository clone URL]
+    sshKey[Private SSH Key]
+    username[basic auth username]
+    password[basic auth password]
+    containerUrl[container URL]
+end
+
+subgraph terraform-runner[unipipe-terraform-runner container in Azure]
+    tr-instanceRepoURL[instance repository clone URL]
+    tr-sshKey[Private SSH Key]
+end
+
+tfoutput[Terraform Output]
+
+username --> tfoutput
+password --> tfoutput
+containerUrl --> tfoutput
+sshKey --register public key--> deployKey
+tr-sshKey <-- same key --> sshKey
+cloneUrl --register clone URL--> instanceRepoURL
+```
+
+## How to use this example
+
+Replace all occurrences of "..." with proper values.
+
+Run `terraform apply`.

--- a/examples/standard-deployment-with-terraform-runner/main.tf
+++ b/examples/standard-deployment-with-terraform-runner/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  # Removing the backend will output the terraform state in the local filesystem
+  # See https://www.terraform.io/language/settings/backends for more details
+  #
+  # Remove/comment the backend block below if you are only testing the module.
+  # Please be aware that you cannot destroy the created resources via terraform if you lose the state file.
+  backend "gcs" {
+    bucket = "..."
+    prefix = "unipipe-demo"
+  }
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "4.22.0"
+    }
+  }
+}
+
+provider "github" {
+  owner = "..." # The GitHub organization the instance repostiory lives in.
+}
+
+# GitHub repository
+resource "github_repository" "instance_repository" {
+  name = "unipipe-demo"
+
+  visibility  = "private"
+  description = "This is the git instance repository used by UniPipe Service Broker."
+}
+
+# UniPipe container on Azure
+module "unipipe" {
+  source = "git::https://github.com/meshcloud/terraform-azure-unipipe.git/?ref=b824997f0b71ba6829832039f9e6b0309253553a"
+
+  subscription_id         = "..." # The subscription the container lives in.
+  unipipe_git_remote      = github_repository.instance_repository.ssh_clone_url
+  unipipe_git_branch      = "main"
+  deploy_terraform_runner = true
+}
+
+# Grant the container access to the GitHub repository.
+resource "github_repository_deploy_key" "unipipe-ssh-key" {
+  title      = "unipipe-service-broker-deploy-key"
+  repository = github_repository.instance_repository.name
+  key        = module.unipipe.unipipe_git_ssh_key
+  read_only  = "false"
+}

--- a/examples/standard-deployment-with-terraform-runner/outputs.tf
+++ b/examples/standard-deployment-with-terraform-runner/outputs.tf
@@ -1,0 +1,12 @@
+output "unipipe_basic_auth_username" {
+  value = module.unipipe.unipipe_basic_auth_username
+}
+
+output "unipipe_basic_auth_password" {
+  value     = module.unipipe.unipipe_basic_auth_password
+  sensitive = true
+}
+
+output "url" {
+  value = module.unipipe.url
+}

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,6 @@ locals {
   #postfix for preventing already-in-use errors
   resource_group_name_postfix          = "${var.resource_group_name}-${random_string.postfix.result}"
   dns_postfix                          = "${var.dns_name_label}-${random_string.postfix.result}"
-  dns_terraform_runner_postfix         = "${var.dns_name_label}-terraform-runner-${random_string.postfix.result}"
   unipipe_storage_account_name_postfix = "unipipeosb${random_string.postfix.result}"
 }
 
@@ -77,10 +76,20 @@ resource "random_string" "postfix" {
 resource "azurerm_container_group" "unipipe_with_ssl" {
   resource_group_name = azurerm_resource_group.unipipe.name
   location            = var.location
-  name                = "unipipe-with-ssl"
+  name                = "unipipe-service-broker"
   os_type             = "Linux"
   dns_name_label      = local.dns_postfix
   ip_address_type     = "Public"
+
+  exposed_port {
+    port     = 443
+    protocol = "TCP"
+  }
+
+  exposed_port {
+    port     = 80
+    protocol = "TCP"
+  }
 
   container {
     name   = "app"
@@ -143,8 +152,7 @@ resource "azurerm_container_group" "unipipe_terraform_runner" {
   location            = var.location
   name                = "unipipe-terraform-runner"
   os_type             = "Linux"
-  dns_name_label      = local.dns_terraform_runner_postfix
-  ip_address_type     = "Private"
+  ip_address_type     = "None"
 
   container {
     name   = "app"

--- a/main.tf
+++ b/main.tf
@@ -155,7 +155,6 @@ resource "azurerm_container_group" "unipipe_terraform_runner" {
       "GIT_USER_EMAIL" = "unipipe-terraform-runner@meshcloud.io"
       "GIT_USER_NAME"  = "Terraform Runner"
       "GIT_REMOTE"     = var.unipipe_git_remote
-      "GIT_REPO"       = var.unipipe_git_remote # Remove when the container can work with GIT_REMOTE
     }
 
     secure_environment_variables = {

--- a/main.tf
+++ b/main.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.0"
+      version = ">=3.29.1"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "3.1.0"
+      version = ">=4.0.4"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.1.0"
+      version = ">=3.4.3"
     }
   }
 }
@@ -57,11 +57,12 @@ resource "azurerm_storage_account" "unipipe" {
 resource "azurerm_storage_share" "acishare" {
   name                 = "acishare"
   storage_account_name = azurerm_storage_account.unipipe.name
+  quota                = 1
 }
 
 # setup a random password for the OSB instance
 resource "random_password" "unipipe_basic_auth_password" {
-  length  = 16
+  length  = 32
   special = false
 }
 
@@ -79,7 +80,7 @@ resource "azurerm_container_group" "unipipe_with_ssl" {
   name                = "unipipe-with-ssl"
   os_type             = "Linux"
   dns_name_label      = local.dns_postfix
-  ip_address_type     = "public"
+  ip_address_type     = "Public"
 
   container {
     name   = "app"
@@ -143,7 +144,7 @@ resource "azurerm_container_group" "unipipe_terraform_runner" {
   name                = "unipipe-terraform-runner"
   os_type             = "Linux"
   dns_name_label      = local.dns_terraform_runner_postfix
-  ip_address_type     = "private"
+  ip_address_type     = "Private"
 
   container {
     name   = "app"

--- a/main.tf
+++ b/main.tf
@@ -158,8 +158,8 @@ resource "azurerm_container_group" "unipipe_terraform_runner" {
       "GIT_REMOTE"     = var.unipipe_git_remote
     }
 
-    secure_environment_variables = {
+    secure_environment_variables = merge({
       "GIT_SSH_KEY" = tls_private_key.unipipe_git_ssh_key.private_key_pem
-    }
+    }, var.terraform_runner_environment_variables)
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,11 @@ variable "unipipe_git_remote" {
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
+variable "deploy_terraform_runner" {
+  type = bool
+  default = false
+  description = "Set this to true if you want to use UniPipe terraform runner"
+}
 variable "resource_group_name" {
   type        = string
   default     = "rg-unipipe-demo"

--- a/variables.tf
+++ b/variables.tf
@@ -7,14 +7,23 @@ variable "unipipe_git_remote" {
   description = "git repo URL, use a deploy key (GitHub) or similar to setup an automation user SSH key for unipipe"
 }
 # ---------------------------------------------------------------------------------------------------------------------
+# TERRAFORM RUNNER PARAMETERS
+# Set these variables if you want to deploy terraform runner
+# ---------------------------------------------------------------------------------------------------------------------
+variable "deploy_terraform_runner" {
+  type        = bool
+  default     = false
+  description = "Set this to true if you want to use UniPipe terraform runner"
+}
+variable "terraform_runner_environment_variables" {
+  type        = map(string)
+  default     = {}
+  description = "Set additional environment variables for terraform-runner container. To authenticate Azure, pass ARM_TENANT_ID, ARM_SUBSCRIPTION_ID, ARM_CLIENT_ID, ARM_SECRET_ID."
+}
+# ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
-variable "deploy_terraform_runner" {
-  type = bool
-  default = false
-  description = "Set this to true if you want to use UniPipe terraform runner"
-}
 variable "resource_group_name" {
   type        = string
   default     = "rg-unipipe-demo"


### PR DESCRIPTION
We want to deploy unipipe-terraform-runner alongside unipipe-service-broker.

Only makes sense to merge this after https://github.com/meshcloud/unipipe-service-broker/pull/97 is merged and a tag triggered the image publication.